### PR TITLE
Merge Visualization Interface Using Polyscope with TetriumColor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ tmp
 .vscode
 *outputs/
 measurements/
+*.mp4
+*.ini
 
 # Mac
 *.DS_Store

--- a/TetriumColor/Observer/DisplayObserverSensitivity.py
+++ b/TetriumColor/Observer/DisplayObserverSensitivity.py
@@ -21,7 +21,8 @@ def GetCustomTetraObserver(wavelengths: npt.NDArray,
                            l_cone_peak: float = 559,
                            macular: float = 1,
                            lens: float = 1,
-                           template="neitz"):
+                           template: str = "neitz",
+                           verbose: bool = False):
     """Given specific parameters, return an observer model with Q cone peaked at 547
 
     Args:
@@ -39,7 +40,7 @@ def GetCustomTetraObserver(wavelengths: npt.NDArray,
     m_cone = Cone.cone(l_cone_peak, wavelengths=wavelengths, template=template, od=od, macular=macular, lens=lens)
     s_cone = Cone.cone(s_cone_peak, wavelengths=wavelengths, template=template, od=od, macular=macular, lens=lens)
     # s_cone = Cone.s_cone(wavelengths=wavelengths)
-    return Observer([s_cone, m_cone, q_cone, l_cone], verbose=False)
+    return Observer([s_cone, m_cone, q_cone, l_cone], verbose=verbose)
 
 
 def GetStockmanObserver(wavelengths: npt.NDArray):

--- a/TetriumColor/Observer/MaxBasis.py
+++ b/TetriumColor/Observer/MaxBasis.py
@@ -6,6 +6,8 @@ from tqdm import tqdm
 import numpy as np
 import os
 import pickle
+import numpy.typing as npt
+from typing import List
 
 from . import Observer, GetHeringMatrix
 from . import Spectra, Illuminant
@@ -160,7 +162,15 @@ class MaxBasis:
         transitions.sort()
         return transitions
 
-    def GetDiscreteRepresentation(self, reverse=False):
+    def GetDiscreteRepresentation(self, reverse=False) -> tuple[List[Spectra], npt.NDArray, npt.NDArray, List[tuple[int, int]]]:
+        """Get discrete representation of max basis
+
+        Args:
+            reverse (bool, optional): Reverse the order of the reflectances to be from bgr to rgb. Defaults to False.
+
+        Returns:
+            tuple[List[Spectra], npt.NDArray, npt.NDArray, List[tuple[int, int]]]: reflectances, points, rgbs, and lines
+        """
         transitions = self.GetCutpointTransitions(self.cutpoints[:self.dimension-1])
         start_vals = [1 if i == 0 else 0 for i, x in enumerate(transitions)]
         allcombos = [[]]

--- a/TetriumColor/Utils/CustomTypes.py
+++ b/TetriumColor/Utils/CustomTypes.py
@@ -10,6 +10,15 @@ class ColorTestResult(Enum):
     Failure = 0
 
 
+class DisplayBasisType(Enum):
+    Cone = 0
+    MaxBasis = 1
+    Hering = 2
+
+    def __str__(self):
+        return self.name
+
+
 class TestType(Enum):
     """
     Three Different Types of Screening Tests Exist.

--- a/TetriumColor/Visualization/Animation.py
+++ b/TetriumColor/Visualization/Animation.py
@@ -1,73 +1,75 @@
-import glm
 import math
+import glm
+import numpy as np
+
+import tetrapolyscope as ps
 
 
 class AnimationUtils:
+    objects = {}  # Centralized object store
+
     @staticmethod
     def RotateObject(rotation_matrix, angle_degrees, axis):
-        """
-        Rotates an object around a given axis.
-        :param rotation_matrix: The initial rotation matrix (glm.mat4).
-        :param angle_degrees: The angle of rotation in degrees.
-        :param axis: The axis of rotation as a glm.vec3 (e.g., glm.vec3(1, 0, 0) for x-axis).
-        :return: Updated rotation matrix (glm.mat4).
-        """
         angle_radians = math.radians(angle_degrees)
         return rotation_matrix * glm.rotate(glm.mat4(1.0), angle_radians, axis)
 
     @staticmethod
     def MoveObject(position, velocity, delta_time):
-        """
-        Moves an object based on velocity and elapsed time.
-        :param position: Current position as a glm.vec3.
-        :param velocity: Velocity vector (glm.vec3).
-        :param delta_time: Elapsed time since the last frame.
-        :return: Updated position (glm.vec3).
-        """
         return position + velocity * delta_time
 
     @staticmethod
     def DecomposeMatrix(matrix):
-        """
-        Decomposes a glm.mat4 into translation, rotation (quaternion), and scale.
-        :param matrix: The input transformation matrix (glm.mat4).
-        :return: (translation, rotation, scale)
-        """
         translation = glm.vec3(matrix[3])
-        scale = glm.vec3(glm.length(matrix[0]), glm.length(
-            matrix[1]), glm.length(matrix[2]))
+        scale = glm.vec3(glm.length(matrix[0]), glm.length(matrix[1]), glm.length(matrix[2]))
         rotation_matrix = glm.mat3(matrix)
-
-        # Normalize the rotation matrix (remove scale influence)
         rotation_matrix[0] /= scale.x
         rotation_matrix[1] /= scale.y
         rotation_matrix[2] /= scale.z
-
         rotation = glm.quat_cast(rotation_matrix)
         return translation, rotation, scale
 
     @staticmethod
     def InterpolateMatrices(matrix1, matrix2, alpha):
-        """
-        Interpolates between two glm.mat4 transformation matrices.
-        :param matrix1: The starting matrix (glm.mat4).
-        :param matrix2: The ending matrix (glm.mat4).
-        :param alpha: Interpolation factor (0.0 = matrix1, 1.0 = matrix2).
-        :return: Interpolated matrix (glm.mat4).
-        """
-        # Decompose both matrices
         t1, r1, s1 = AnimationUtils.DecomposeMatrix(matrix1)
         t2, r2, s2 = AnimationUtils.DecomposeMatrix(matrix2)
-
-        # Interpolate translation, rotation, and scale
         interpolated_translation = glm.mix(t1, t2, alpha)
         interpolated_rotation = glm.slerp(r1, r2, alpha)
         interpolated_scale = glm.mix(s1, s2, alpha)
-
-        # Reconstruct the matrix
-        translation_matrix = glm.translate(
-            glm.mat4(1.0), interpolated_translation)
+        translation_matrix = glm.translate(glm.mat4(1.0), interpolated_translation)
         rotation_matrix = glm.mat4_cast(interpolated_rotation)
         scale_matrix = glm.scale(glm.mat4(1.0), interpolated_scale)
-
         return translation_matrix * rotation_matrix * scale_matrix
+
+    @staticmethod
+    def AddObject(name, ps_type, position, velocity, rotation_axis, rotation_speed):
+        AnimationUtils.objects[name] = {
+            "name": name,
+            "type": ps_type,
+            "position": glm.vec3(position),
+            "velocity": glm.vec3(velocity),
+            "rotation_axis": glm.vec3(rotation_axis),
+            "rotation_speed": rotation_speed,
+            "rotation_matrix": glm.mat4(1.0),
+        }
+
+    @staticmethod
+    def UpdateObjects(delta_time):
+        for name, obj in AnimationUtils.objects.items():
+            # Update position
+            obj["position"] = AnimationUtils.MoveObject(
+                obj["position"], obj["velocity"], delta_time
+            )
+
+            # Update rotation
+            obj["rotation_matrix"] = AnimationUtils.RotateObject(
+                obj["rotation_matrix"],
+                obj["rotation_speed"] * delta_time,
+                obj["rotation_axis"]
+            )
+
+            # Translation matrix
+            translation_matrix = glm.translate(glm.mat4(1.0), obj["position"])
+            transformation_matrix = translation_matrix * obj["rotation_matrix"]
+
+            # If Polyscope supports dynamic updates, apply transformation_matrix here
+            getattr(ps, f"get_{obj['type']}")(obj["name"]).set_transform(transformation_matrix)

--- a/TetriumColor/Visualization/Animation.py
+++ b/TetriumColor/Visualization/Animation.py
@@ -1,0 +1,73 @@
+import glm
+import math
+
+
+class AnimationUtils:
+    @staticmethod
+    def RotateObject(rotation_matrix, angle_degrees, axis):
+        """
+        Rotates an object around a given axis.
+        :param rotation_matrix: The initial rotation matrix (glm.mat4).
+        :param angle_degrees: The angle of rotation in degrees.
+        :param axis: The axis of rotation as a glm.vec3 (e.g., glm.vec3(1, 0, 0) for x-axis).
+        :return: Updated rotation matrix (glm.mat4).
+        """
+        angle_radians = math.radians(angle_degrees)
+        return rotation_matrix * glm.rotate(glm.mat4(1.0), angle_radians, axis)
+
+    @staticmethod
+    def MoveObject(position, velocity, delta_time):
+        """
+        Moves an object based on velocity and elapsed time.
+        :param position: Current position as a glm.vec3.
+        :param velocity: Velocity vector (glm.vec3).
+        :param delta_time: Elapsed time since the last frame.
+        :return: Updated position (glm.vec3).
+        """
+        return position + velocity * delta_time
+
+    @staticmethod
+    def DecomposeMatrix(matrix):
+        """
+        Decomposes a glm.mat4 into translation, rotation (quaternion), and scale.
+        :param matrix: The input transformation matrix (glm.mat4).
+        :return: (translation, rotation, scale)
+        """
+        translation = glm.vec3(matrix[3])
+        scale = glm.vec3(glm.length(matrix[0]), glm.length(
+            matrix[1]), glm.length(matrix[2]))
+        rotation_matrix = glm.mat3(matrix)
+
+        # Normalize the rotation matrix (remove scale influence)
+        rotation_matrix[0] /= scale.x
+        rotation_matrix[1] /= scale.y
+        rotation_matrix[2] /= scale.z
+
+        rotation = glm.quat_cast(rotation_matrix)
+        return translation, rotation, scale
+
+    @staticmethod
+    def InterpolateMatrices(matrix1, matrix2, alpha):
+        """
+        Interpolates between two glm.mat4 transformation matrices.
+        :param matrix1: The starting matrix (glm.mat4).
+        :param matrix2: The ending matrix (glm.mat4).
+        :param alpha: Interpolation factor (0.0 = matrix1, 1.0 = matrix2).
+        :return: Interpolated matrix (glm.mat4).
+        """
+        # Decompose both matrices
+        t1, r1, s1 = AnimationUtils.DecomposeMatrix(matrix1)
+        t2, r2, s2 = AnimationUtils.DecomposeMatrix(matrix2)
+
+        # Interpolate translation, rotation, and scale
+        interpolated_translation = glm.mix(t1, t2, alpha)
+        interpolated_rotation = glm.slerp(r1, r2, alpha)
+        interpolated_scale = glm.mix(s1, s2, alpha)
+
+        # Reconstruct the matrix
+        translation_matrix = glm.translate(
+            glm.mat4(1.0), interpolated_translation)
+        rotation_matrix = glm.mat4_cast(interpolated_rotation)
+        scale_matrix = glm.scale(glm.mat4(1.0), interpolated_scale)
+
+        return translation_matrix * rotation_matrix * scale_matrix

--- a/TetriumColor/Visualization/Animation.py
+++ b/TetriumColor/Visualization/Animation.py
@@ -6,35 +6,85 @@ import tetrapolyscope as ps
 
 
 class AnimationUtils:
-    objects = {}  # Centralized object store
+    # Centralized store for objects being animated, where each object is identified by a unique name
+    objects = {}
 
     @staticmethod
     def RotateObject(rotation_matrix, angle_degrees, axis):
-        angle_radians = math.radians(angle_degrees)
+        """
+        Rotates an object around a specified axis by a given angle.
+
+        Parameters:
+            rotation_matrix (glm.mat4): The current rotation matrix of the object.
+            angle_degrees (float): The angle of rotation in degrees.
+            axis (glm.vec3): The axis of rotation (e.g., x, y, or z).
+
+        Returns:
+            glm.mat4: The updated rotation matrix after applying the rotation.
+        """
+        angle_radians = math.radians(angle_degrees)  # Convert angle to radians
         return rotation_matrix * glm.rotate(glm.mat4(1.0), angle_radians, axis)
 
     @staticmethod
     def MoveObject(position, velocity, delta_time):
+        """
+        Updates the position of an object based on its velocity and elapsed time.
+
+        Parameters:
+            position (glm.vec3): The current position of the object.
+            velocity (glm.vec3): The velocity vector of the object.
+            delta_time (float): The time step for the update.
+
+        Returns:
+            glm.vec3: The updated position of the object.
+        """
         return position + velocity * delta_time
 
     @staticmethod
     def DecomposeMatrix(matrix):
-        translation = glm.vec3(matrix[3])
-        scale = glm.vec3(glm.length(matrix[0]), glm.length(matrix[1]), glm.length(matrix[2]))
-        rotation_matrix = glm.mat3(matrix)
+        """
+        Decomposes a transformation matrix into its translation, rotation, and scale components.
+
+        Parameters:
+            matrix (glm.mat4): The transformation matrix to decompose.
+
+        Returns:
+            tuple: A tuple containing the translation (glm.vec3), rotation (glm.quat), 
+                   and scale (glm.vec3) components.
+        """
+        translation = glm.vec3(matrix[3])  # Extract the translation vector
+        scale = glm.vec3(glm.length(matrix[0]), glm.length(matrix[1]), glm.length(matrix[2]))  # Compute scale factors
+        rotation_matrix = glm.mat3(matrix)  # Extract rotation matrix by removing translation
+        # Normalize rotation matrix by dividing each axis vector by its scale factor
         rotation_matrix[0] /= scale.x
         rotation_matrix[1] /= scale.y
         rotation_matrix[2] /= scale.z
-        rotation = glm.quat_cast(rotation_matrix)
+        rotation = glm.quat_cast(rotation_matrix)  # Convert rotation matrix to quaternion
         return translation, rotation, scale
 
     @staticmethod
     def InterpolateMatrices(matrix1, matrix2, alpha):
+        """
+        Interpolates between two transformation matrices.
+
+        Parameters:
+            matrix1 (glm.mat4): The starting transformation matrix.
+            matrix2 (glm.mat4): The target transformation matrix.
+            alpha (float): The interpolation factor (0.0 to 1.0).
+
+        Returns:
+            glm.mat4: The interpolated transformation matrix.
+        """
+        # Decompose both matrices into translation, rotation, and scale
         t1, r1, s1 = AnimationUtils.DecomposeMatrix(matrix1)
         t2, r2, s2 = AnimationUtils.DecomposeMatrix(matrix2)
+
+        # Interpolate each component
         interpolated_translation = glm.mix(t1, t2, alpha)
         interpolated_rotation = glm.slerp(r1, r2, alpha)
         interpolated_scale = glm.mix(s1, s2, alpha)
+
+        # Reconstruct the transformation matrix
         translation_matrix = glm.translate(glm.mat4(1.0), interpolated_translation)
         rotation_matrix = glm.mat4_cast(interpolated_rotation)
         scale_matrix = glm.scale(glm.mat4(1.0), interpolated_scale)
@@ -42,6 +92,17 @@ class AnimationUtils:
 
     @staticmethod
     def AddObject(name, ps_type, position, velocity, rotation_axis, rotation_speed):
+        """
+        Adds an object to the centralized object store with initial properties.
+
+        Parameters:
+            name (str): Unique name for the object.
+            ps_type (str): Polyscope type (e.g., "sphere", "arrow").
+            position (list or glm.vec3): Initial position of the object.
+            velocity (list or glm.vec3): Initial velocity of the object.
+            rotation_axis (list or glm.vec3): Axis of rotation.
+            rotation_speed (float): Speed of rotation in degrees per second.
+        """
         AnimationUtils.objects[name] = {
             "name": name,
             "type": ps_type,
@@ -49,27 +110,33 @@ class AnimationUtils:
             "velocity": glm.vec3(velocity),
             "rotation_axis": glm.vec3(rotation_axis),
             "rotation_speed": rotation_speed,
-            "rotation_matrix": glm.mat4(1.0),
+            "rotation_matrix": glm.mat4(1.0),  # Initial rotation matrix (identity matrix)
         }
 
     @staticmethod
     def UpdateObjects(delta_time):
+        """
+        Updates the position and rotation of all objects in the centralized store.
+
+        Parameters:
+            delta_time (float): The time step for the update.
+        """
         for name, obj in AnimationUtils.objects.items():
-            # Update position
+            # Update position based on velocity
             obj["position"] = AnimationUtils.MoveObject(
                 obj["position"], obj["velocity"], delta_time
             )
 
-            # Update rotation
+            # Update rotation based on rotation speed and axis
             obj["rotation_matrix"] = AnimationUtils.RotateObject(
                 obj["rotation_matrix"],
                 obj["rotation_speed"] * delta_time,
                 obj["rotation_axis"]
             )
 
-            # Translation matrix
+            # Create a transformation matrix combining translation and rotation
             translation_matrix = glm.translate(glm.mat4(1.0), obj["position"])
             transformation_matrix = translation_matrix * obj["rotation_matrix"]
 
-            # If Polyscope supports dynamic updates, apply transformation_matrix here
+            # Apply the transformation to the Polyscope object (if supported)
             getattr(ps, f"get_{obj['type']}")(obj["name"]).set_transform(transformation_matrix)

--- a/TetriumColor/Visualization/Geometry.py
+++ b/TetriumColor/Visualization/Geometry.py
@@ -8,7 +8,7 @@ from itertools import combinations
 import tetrapolyscope as ps
 
 
-def GetCylinderTransform(endpoints):
+def GetCylinderTransform(endpoints: List | tuple | npt.NDArray) -> glm.mat4:
     a = endpoints[1]-endpoints[0]
     a = glm.vec3(a[0], a[1], a[2])
     b = glm.vec3(0, 0, 1)
@@ -33,20 +33,47 @@ def GetCylinderTransform(endpoints):
 class GeometryPrimitives:
 
     def __init__(self) -> None:
+        """Initializes the GeometryPrimitives class.
+        """
         self.objects = []
 
     def add_obj(self, obj: o3d.geometry.TriangleMesh) -> None:
+        """Add an object to an instance of the class.
+
+        Args:
+            obj (o3d.geometry.TriangleMesh): triangle mesh object to be added.
+        """
         self.objects.append(obj)
 
     @staticmethod
     def CollapseMeshObjects(objects: List[o3d.geometry.TriangleMesh]) -> o3d.geometry.TriangleMesh:
+        """Collapse all objects in list into a single mesh.
+
+        Args:
+            objects (List[o3d.geometry.TriangleMesh]): List of objects
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh object
+        """
         mesh = o3d.geometry.TriangleMesh()
         for obj in objects:
             mesh += obj
         return mesh
 
     @staticmethod
-    def CreateSphere(radius: float = 0.025, center: List | tuple | npt.NDArray = [0, 0, 0], resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+    def CreateSphere(radius: float = 0.025, center: List | tuple | npt.NDArray = [0, 0, 0],
+                     resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        """Create a sphere mesh.
+
+        Args:
+            radius (float, optional): radius of sphere. Defaults to 0.025.
+            center (List | tuple | npt.NDArray, optional): position of center of sphere. Defaults to [0, 0, 0].
+            resolution (float, optional): resolution of the mesh. Defaults to 20.
+            color (List | tuple | npt.NDArray, optional): color of mesh. Defaults to [0, 0, 0].
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of sphere
+        """
         mesh = o3d.geometry.TriangleMesh.create_sphere(
             radius=radius, resolution=resolution)
         mesh.translate(center)
@@ -56,7 +83,19 @@ class GeometryPrimitives:
         return mesh
 
     @staticmethod
-    def CreateCylinder(endpoints: List | tuple | npt.NDArray, radius: float = 0.025/2, resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+    def CreateCylinder(endpoints: List | tuple | npt.NDArray, radius: float = 0.025/2,
+                       resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        """Cylinder Mesh
+
+        Args:
+            endpoints (List | tuple | npt.NDArray): endpoints of the cylinder
+            radius (float, optional): radius of the cylinder. Defaults to 0.025/2.
+            resolution (float, optional): resolution of mesh for cylinder. Defaults to 20.
+            color (List | tuple | npt.NDArray, optional): color of cylinder. Defaults to [0, 0, 0].
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of cylinder
+        """
         # canonical cylinder is along z axis with height 1 and centered
         mesh = o3d.geometry.TriangleMesh.create_cylinder(
             radius=radius, height=1, resolution=resolution)
@@ -70,7 +109,15 @@ class GeometryPrimitives:
         return mesh
 
     @staticmethod
-    def calculate_zy_rotation_for_arrow(vec):
+    def calculate_zy_rotation_for_arrow(vec: npt.NDArray) -> tuple:
+        """Generate 3d rotation matrix for an z axis defined arrow given a vector
+
+        Args:
+            vec (npt.NDArray): vector defining the endpoints of transform
+
+        Returns:
+            tuple: rotation matrices for z and y axisR
+        """
         gamma = np.arctan2(vec[1], vec[0])
         Rz = np.array([
             [np.cos(gamma), -np.sin(gamma), 0],
@@ -89,7 +136,17 @@ class GeometryPrimitives:
         return Rz, Ry
 
     @staticmethod
-    def GetArrow(endpoint: List | tuple | npt.NDArray, origin: List | tuple | npt.NDArray = np.array([0, 0, 0]), scale: float = 1):
+    def _getArrow(endpoint: List | tuple | npt.NDArray, origin: List | tuple | npt.NDArray = np.array([0, 0, 0]), scale: float = 1):
+        """Get Arrow Mesh
+
+        Args:
+            endpoint (List | tuple | npt.NDArray): end point of arrow
+            origin (List | tuple | npt.NDArray, optional): origin of the arrow. Defaults to np.array([0, 0, 0]).
+            scale (float, optional): scale of arrow. Defaults to 1.
+
+        Returns:
+            _type_: Arrow Mesh in open3d format
+        """
         assert (not np.all(endpoint == origin))
         vec = np.array(endpoint) - np.array(origin)
         size = np.sqrt(np.sum(vec**2))
@@ -109,7 +166,19 @@ class GeometryPrimitives:
 
     @staticmethod
     def CreateArrow(endpoints: npt.NDArray, radius: float = 0.025/2, resolution: float = 20, scale: float = 1, color: List | tuple | npt.NDArray = np.array([0, 0, 0])) -> o3d.geometry.TriangleMesh:
-        mesh = GeometryPrimitives.GetArrow(
+        """Get Arrow Mesh
+
+        Args:
+            endpoints (npt.NDArray): endpoints of the mesh
+            radius (float, optional): radius of arrow. Defaults to 0.025/2.
+            resolution (float, optional): resolution of the mesh. Defaults to 20.
+            scale (float, optional): scale of the mesh. Defaults to 1.
+            color (List | tuple | npt.NDArray, optional): color of the mesh. Defaults to np.array([0, 0, 0]).
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of arrow 
+        """
+        mesh = GeometryPrimitives._getArrow(
             endpoints[1], endpoints[0], scale=scale)
         mesh.compute_vertex_normals()
         mesh.vertex_colors = o3d.utility.Vector3dVector(
@@ -117,7 +186,20 @@ class GeometryPrimitives:
         return mesh
 
     @staticmethod
-    def CreateCoordinateBasis(basis: npt.NDArray, radius: float = 0.025/2, resolution: float = 20, scale: float = 1, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+    def CreateCoordinateBasis(basis: npt.NDArray, radius: float = 0.025/2, resolution: float = 20,
+                              scale: float = 1, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        """Create a coordinate basis mesh
+
+        Args:
+            basis (npt.NDArray): basis vectors (can be n x 3)
+            radius (float, optional): radius of mesh. Defaults to 0.025/2.
+            resolution (float, optional): resolution of mesh. Defaults to 20.
+            scale (float, optional): scale of mesh. Defaults to 1.
+            color (List | tuple | npt.NDArray, optional): color of mesh. Defaults to [0, 0, 0].
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of coordinate basis
+        """
         meshes = []
         for i, b in enumerate(basis):
             mesh = GeometryPrimitives.CreateArrow(
@@ -127,18 +209,43 @@ class GeometryPrimitives:
         return mesh
 
     @staticmethod
-    def CreateMaxBasis(points: npt.NDArray, rgbs: npt.NDArray | List[List], lines: npt.NDArray | List[List | tuple], ball_radius: float = 0.025) -> o3d.geometry.TriangleMesh:
+    def CreateMaxBasis(points: npt.NDArray, rgbs: npt.NDArray | List[List],
+                       lines: npt.NDArray | List[List | tuple], line_color: List[List] | npt.NDArray = [0, 0, 0],
+                       ball_radius: float = 0.025) -> o3d.geometry.TriangleMesh:
+        """Create a mesh of points and lines to represent the max basis
+
+        Args:
+            points (npt.NDArray): array of 3d points
+            rgbs (npt.NDArray | List[List]): array of rgb values associated with points
+            lines (npt.NDArray | List[List  |  tuple]): list of pairs of indices to draw lines with each other
+            line_color (List[List] | npt.NDArray, optional): color of lines. Defaults to [0, 0, 0].
+            ball_radius (float, optional): radisu of ball. Defaults to 0.025.
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of max basis
+        """
         objs = []
         for rgb, point in zip(rgbs, points):
             objs += [GeometryPrimitives.CreateSphere(
                 center=point, color=rgb, radius=ball_radius)]
         for line in lines:
             objs += [GeometryPrimitives.CreateCylinder(
-                endpoints=[points[line[0]], points[line[1]]], color=[0, 0, 0])]
+                endpoints=[points[line[0]], points[line[1]]], color=line_color)]
         return GeometryPrimitives.CollapseMeshObjects(objs)
 
     @staticmethod
-    def CreateParallelotopeEdges(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0], line_color: List | tuple | npt.NDArray = [0, 0, 0], line_alpha: float = 1) -> o3d.geometry.TriangleMesh:
+    def CreateParallelotopeEdges(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0],
+                                 line_color: List | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        """Paralleletope Edges
+
+        Args:
+            basis (npt.NDArray): basis vectors for the paralleletope (equal to dimension)
+            color (List | tuple | npt.NDArray, optional): color of points. Defaults to [0, 0, 0].
+            line_color (List | npt.NDArray, optional): color of lines. Defaults to [0, 0, 0].
+
+        Returns:
+            o3d.geometry.TriangleMesh: returns the open3d triangle mesh of the paralleletope edges
+        """
         dim = basis.shape[1]
         if dim < 3:
             raise ValueError("Basis must be at least 3D")
@@ -170,10 +277,19 @@ class GeometryPrimitives:
                               [(basis[i] + basis[j] + basis[k]).tolist() for i in range(4) for j in range(i+1, 4) for k in range(j+1, 4)] +
                               [(basis[0] + basis[1] + basis[2] + basis[3]).tolist()])
         rgbs = np.array([color]*len(points))
-        return GeometryPrimitives.CreateMaxBasis(points, rgbs, lines, ball_radius=0.025)
+        return GeometryPrimitives.CreateMaxBasis(points, rgbs, lines, line_color=line_color, ball_radius=0.025)
 
     @staticmethod
-    def CreateParallelotopeMesh(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0], line_color: List | tuple | npt.NDArray = [0, 0, 0], line_alpha: float = 1) -> o3d.geometry.TriangleMesh:
+    def CreateParallelotopeMesh(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        """Create Mesh of Paralleletope
+
+        Args:
+            basis (npt.NDArray): basis vectors that define paralleletope (equal to dimension of space)
+            color (List | tuple | npt.NDArray, optional): color of mesh. Defaults to [0, 0, 0].
+
+        Returns:
+            o3d.geometry.TriangleMesh: open3d triangle mesh of paralleletope
+        """
         dim = basis.shape[1]
         if dim < 3:
             raise ValueError("Basis must be at least 3D")
@@ -195,7 +311,16 @@ class GeometryPrimitives:
         return GeometryPrimitives.Create3DMesh(points, rgbs)
 
     @staticmethod
-    def Create3DMesh(points, rgbs):
+    def Create3DMesh(points, rgbs) -> o3d.geometry.TriangleMesh:
+        """Create a 3D Mesh from a point cloud and associated rgbs.
+
+        Args:
+            points (_type_): points in 3D space
+            rgbs (_type_): associated rgbs
+
+        Returns:
+            o3d.geometry.TriangleMesh: Point cloud mesh
+        """
         pcl = o3d.geometry.PointCloud()
         pcl.points = o3d.utility.Vector3dVector(points)
         mesh, point_indices = pcl.compute_convex_hull()
@@ -206,6 +331,12 @@ class GeometryPrimitives:
 
     @staticmethod
     def ConvertTriangleMeshToPolyscope(name: str, mesh: o3d.geometry.TriangleMesh) -> None:
+        """Convert open3d triangle mesh to polyscope mesh
+
+        Args:
+            name (str): name of the mesh to be registered with polyscope
+            mesh (o3d.geometry.TriangleMesh): open3d geometry triangle mesh to be converted
+        """
         ps_mesh = ps.register_surface_mesh(f"{name}", np.asarray(mesh.vertices), np.asarray(
             mesh.triangles), material='wax', smooth_shade=True)
         ps_mesh.add_color_quantity(f"{name}_colors", np.asarray(

--- a/TetriumColor/Visualization/Geometry.py
+++ b/TetriumColor/Visualization/Geometry.py
@@ -1,0 +1,212 @@
+import numpy as np
+from typing import List
+import numpy.typing as npt
+
+import open3d as o3d
+import glm
+from itertools import combinations
+import tetrapolyscope as ps
+
+
+def GetCylinderTransform(endpoints):
+    a = endpoints[1]-endpoints[0]
+    a = glm.vec3(a[0], a[1], a[2])
+    b = glm.vec3(0, 0, 1)
+
+    mat = glm.mat4()
+    # translate
+    mat = glm.translate(mat, glm.vec3(
+        endpoints[0][0], endpoints[0][1], endpoints[0][2]))
+    # rotate
+    v = glm.cross(b, a)
+    if v != glm.vec3(0, 0, 0):
+        angle = glm.acos(glm.dot(b, a) / (glm.length(b) * glm.length(a)))
+        mat = glm.rotate(mat, angle, v)
+
+    # scale
+    scale_factor = glm.length(a)
+    mat = glm.scale(mat, glm.vec3(scale_factor, scale_factor, scale_factor))
+
+    return mat
+
+
+class GeometryPrimitives:
+
+    def __init__(self) -> None:
+        self.objects = []
+
+    def add_obj(self, obj: o3d.geometry.TriangleMesh) -> None:
+        self.objects.append(obj)
+
+    @staticmethod
+    def CollapseMeshObjects(objects: List[o3d.geometry.TriangleMesh]) -> o3d.geometry.TriangleMesh:
+        mesh = o3d.geometry.TriangleMesh()
+        for obj in objects:
+            mesh += obj
+        return mesh
+
+    @staticmethod
+    def CreateSphere(radius: float = 0.025, center: List | tuple | npt.NDArray = [0, 0, 0], resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        mesh = o3d.geometry.TriangleMesh.create_sphere(
+            radius=radius, resolution=resolution)
+        mesh.translate(center)
+        mesh.vertex_colors = o3d.utility.Vector3dVector(
+            np.array([color]*len(mesh.vertices)))
+        mesh.compute_vertex_normals()
+        return mesh
+
+    @staticmethod
+    def CreateCylinder(endpoints: List | tuple | npt.NDArray, radius: float = 0.025/2, resolution: float = 20, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        # canonical cylinder is along z axis with height 1 and centered
+        mesh = o3d.geometry.TriangleMesh.create_cylinder(
+            radius=radius, height=1, resolution=resolution)
+        mesh.translate([0, 0, 1/2])
+
+        matrix = GetCylinderTransform(endpoints)
+        mesh.transform(matrix)
+        mesh.vertex_colors = o3d.utility.Vector3dVector(
+            np.array([color]*len(mesh.vertices)))
+        mesh.compute_vertex_normals()
+        return mesh
+
+    @staticmethod
+    def calculate_zy_rotation_for_arrow(vec):
+        gamma = np.arctan2(vec[1], vec[0])
+        Rz = np.array([
+            [np.cos(gamma), -np.sin(gamma), 0],
+            [np.sin(gamma), np.cos(gamma), 0],
+            [0, 0, 1]
+        ])
+
+        vec = Rz.T @ vec
+
+        beta = np.arctan2(vec[0], vec[2])
+        Ry = np.array([
+            [np.cos(beta), 0, np.sin(beta)],
+            [0, 1, 0],
+            [-np.sin(beta), 0, np.cos(beta)]
+        ])
+        return Rz, Ry
+
+    @staticmethod
+    def GetArrow(endpoint: List | tuple | npt.NDArray, origin: List | tuple | npt.NDArray = np.array([0, 0, 0]), scale: float = 1):
+        assert (not np.all(endpoint == origin))
+        vec = np.array(endpoint) - np.array(origin)
+        size = np.sqrt(np.sum(vec**2))
+        ratio_cone_cylinder = 0.15
+        radius = 60
+        ratio_cone_bottom_to_cylinder = 2
+
+        Rz, Ry = GeometryPrimitives.calculate_zy_rotation_for_arrow(vec)
+        mesh = o3d.geometry.TriangleMesh.create_arrow(cone_radius=1/radius * ratio_cone_bottom_to_cylinder * scale,
+                                                      cone_height=size * ratio_cone_cylinder * scale,
+                                                      cylinder_radius=1/radius * scale,
+                                                      cylinder_height=size * (1 - ratio_cone_cylinder * scale))
+        mesh.rotate(Ry, center=np.array([0, 0, 0]))
+        mesh.rotate(Rz, center=np.array([0, 0, 0]))
+        mesh.translate(origin)
+        return (mesh)
+
+    @staticmethod
+    def CreateArrow(endpoints: npt.NDArray, radius: float = 0.025/2, resolution: float = 20, scale: float = 1, color: List | tuple | npt.NDArray = np.array([0, 0, 0])) -> o3d.geometry.TriangleMesh:
+        mesh = GeometryPrimitives.GetArrow(
+            endpoints[1], endpoints[0], scale=scale)
+        mesh.compute_vertex_normals()
+        mesh.vertex_colors = o3d.utility.Vector3dVector(
+            np.array([color]*len(mesh.vertices)))
+        return mesh
+
+    @staticmethod
+    def CreateCoordinateBasis(basis: npt.NDArray, radius: float = 0.025/2, resolution: float = 20, scale: float = 1, color: List | tuple | npt.NDArray = [0, 0, 0]) -> o3d.geometry.TriangleMesh:
+        meshes = []
+        for i, b in enumerate(basis):
+            mesh = GeometryPrimitives.CreateArrow(
+                endpoints=np.array([[0, 0, 0], b]), radius=radius, resolution=resolution, color=color[i], scale=scale)
+            meshes.append(mesh)
+        mesh = GeometryPrimitives.CollapseMeshObjects(meshes)
+        return mesh
+
+    @staticmethod
+    def CreateMaxBasis(points: npt.NDArray, rgbs: npt.NDArray | List[List], lines: npt.NDArray | List[List | tuple], ball_radius: float = 0.025) -> o3d.geometry.TriangleMesh:
+        objs = []
+        for rgb, point in zip(rgbs, points):
+            objs += GeometryPrimitives.CreateSphere(
+                center=point, color=rgb, radius=ball_radius)
+        for line in lines:
+            objs += [GeometryPrimitives.CreateCylinder(
+                endpoints=[points[line[0]], points[line[1]]], color=[0, 0, 0])]
+        return GeometryPrimitives.CollapseMeshObjects(objs)
+
+    @staticmethod
+    def CreateParallelotopeEdges(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0], line_color: List | tuple | npt.NDArray = [0, 0, 0], line_alpha: float = 1) -> o3d.geometry.TriangleMesh:
+        dim = basis.shape[1]
+        if dim < 3:
+            raise ValueError("Basis must be at least 3D")
+        elif dim > 4:
+            raise ValueError("Basis must be at most 4D")
+
+        alllines = []
+        for i in range(dim):
+            alllines += list(combinations(range(dim), i + 1))
+
+        lines = []
+        for i, x in enumerate(alllines):
+            if len(x) <= 1:
+                lines += [[0, x[0] + 1]]  # connected to black
+            else:  # > 1
+                madeupof = list(combinations(x, len(x)-1))
+                lines += [[alllines.index(elem) + 1, i + 1]
+                          for elem in madeupof]  # connected to each elem
+
+        if dim == 3:
+            # # Create points of the parallelepiped
+            points = np.array([[0, 0, 0]] + [basis[i].tolist() for i in range(3)] +
+                              [(basis[i] + basis[j]).tolist() for i in range(3) for j in range(i+1, 3)] +
+                              [(basis[0] + basis[1] + basis[2]).tolist()])
+        else:
+            # Create points of the 4D paralleletope
+            points = np.array([[0, 0, 0, 0]] + [basis[i].tolist() for i in range(4)] +
+                              [(basis[i] + basis[j]).tolist() for i in range(4) for j in range(i+1, 4)] +
+                              [(basis[i] + basis[j] + basis[k]).tolist() for i in range(4) for j in range(i+1, 4) for k in range(j+1, 4)] +
+                              [(basis[0] + basis[1] + basis[2] + basis[3]).tolist()])
+        rgbs = np.array([color]*len(points))
+        return GeometryPrimitives.CreateMaxBasis(points, rgbs, lines, ball_radius=0.025)
+
+    @staticmethod
+    def CreateParallelotopeMesh(basis: npt.NDArray, color: List | tuple | npt.NDArray = [0, 0, 0], line_color: List | tuple | npt.NDArray = [0, 0, 0], line_alpha: float = 1) -> o3d.geometry.TriangleMesh:
+        dim = basis.shape[1]
+        if dim < 3:
+            raise ValueError("Basis must be at least 3D")
+        elif dim > 4:
+            raise ValueError("Basis must be at most 4D")
+
+        if dim == 3:
+            # # Create points of the parallelepiped
+            points = np.array([[0, 0, 0]] + [basis[i].tolist() for i in range(3)] +
+                              [(basis[i] + basis[j]).tolist() for i in range(3) for j in range(i+1, 3)] +
+                              [(basis[0] + basis[1] + basis[2]).tolist()])
+        else:
+            # Create points of the 4D paralleletope
+            points = np.array([[0, 0, 0, 0]] + [basis[i].tolist() for i in range(4)] +
+                              [(basis[i] + basis[j]).tolist() for i in range(4) for j in range(i+1, 4)] +
+                              [(basis[i] + basis[j] + basis[k]).tolist() for i in range(4) for j in range(i+1, 4) for k in range(j+1, 4)] +
+                              [(basis[0] + basis[1] + basis[2] + basis[3]).tolist()])
+        rgbs = np.array([color]*len(points))
+        return GeometryPrimitives.Create3DMesh(points, rgbs)
+
+    @staticmethod
+    def Create3DMesh(points, rgbs):
+        pcl = o3d.geometry.PointCloud()
+        pcl.points = o3d.utility.Vector3dVector(points)
+        mesh, point_indices = pcl.compute_convex_hull()
+        mesh.compute_vertex_normals()
+
+        mesh.vertex_colors = o3d.utility.Vector3dVector(rgbs[point_indices])
+        return mesh
+
+    @staticmethod
+    def ConvertTriangleMeshToPolyscope(name: str, mesh: o3d.geometry.TriangleMesh) -> None:
+        ps_mesh = ps.register_surface_mesh(f"{name}", np.asarray(mesh.vertices), np.asarray(
+            mesh.triangles), material='wax', smooth_shade=True)
+        ps_mesh.add_color_quantity(f"{name}_colors", np.asarray(
+            mesh.vertex_colors), defined_on='vertices', enabled=True)

--- a/TetriumColor/Visualization/Geometry.py
+++ b/TetriumColor/Visualization/Geometry.py
@@ -130,8 +130,8 @@ class GeometryPrimitives:
     def CreateMaxBasis(points: npt.NDArray, rgbs: npt.NDArray | List[List], lines: npt.NDArray | List[List | tuple], ball_radius: float = 0.025) -> o3d.geometry.TriangleMesh:
         objs = []
         for rgb, point in zip(rgbs, points):
-            objs += GeometryPrimitives.CreateSphere(
-                center=point, color=rgb, radius=ball_radius)
+            objs += [GeometryPrimitives.CreateSphere(
+                center=point, color=rgb, radius=ball_radius)]
         for line in lines:
             objs += [GeometryPrimitives.CreateCylinder(
                 endpoints=[points[line[0]], points[line[1]]], color=[0, 0, 0])]

--- a/TetriumColor/Visualization/PolyscopeUtils.py
+++ b/TetriumColor/Visualization/PolyscopeUtils.py
@@ -1,0 +1,144 @@
+from typing import Callable
+from colour.recovery.jakob2019 import dimensionalise_coefficients
+from matplotlib.pyplot import arrow
+import numpy as np
+import numpy.typing as npt
+
+import tetrapolyscope as ps
+
+from .Geometry import GeometryPrimitives
+from ..Observer import Observer, MaxBasisFactory, GetHeringMatrix
+
+
+def OpenVideo(filename):
+    return ps.open_video_file(filename, fps=30)
+
+
+def CloseVideo(fd):
+    ps.close_video_file(fd)
+    return
+
+
+def RenderVideo(updateAnimation: Callable[[float], None], fd, total_frames: int, target_fps: int = 30):
+    delta_time: float = 1 / target_fps
+    for i in range(total_frames):
+        updateAnimation(delta_time)
+        ps.write_video_frame(fd, transparent_bg=False)
+
+
+def Render3DMesh(name: str, points: npt.ArrayLike, rgbs: npt.ArrayLike, mesh_alpha: float = 1) -> None:
+    """Create a 3D mesh from a list of vertices (N x 3) and RGB colors (N x 3)
+
+    Args:
+        name (str): Name of the mesh
+        points (npt.ArrayLike): N x 3 array of vertices
+        rgbs (npt.ArrayLike): N x 3 array of RGB colors
+
+    Returns:
+        _type_: _description_
+    """
+    mesh = GeometryPrimitives.Create3DMesh(points, rgbs)
+    GeometryPrimitives.ConvertTriangleMeshToPolyscope(name, mesh)
+
+
+def Render3DCone(name: str, points: npt.NDArray, color: npt.NDArray, mesh_alpha: float = 1, arrow_alpha: float = 1) -> None:
+    """Create a 3D cone from a list of vertices (N x 3) and a color (3)
+
+    Args:
+        name (str): basename for the cone asset
+        points (npt.NDArray): N x 3 array of vertices
+        color (npt.ArrayLike): 1 x 3 Array of RGB color
+        mesh_alpha (float, optional): Transparency of the Mesh. Defaults to 1.
+        arrow_alpha (float, optional): Transparency of the Arrows. Defaults to 1.
+    """
+    center_vertex = np.zeros(points.shape[1])
+    vertices = np.concatenate([[center_vertex], points])
+    triangles = [[0, i, i + 1] for i in range(1, len(vertices) - 1)]
+    ps_mesh = ps.register_surface_mesh(f"{name}", np.asarray(vertices), np.asarray(
+        triangles), transparency=mesh_alpha, material='wax', smooth_shade=True)
+    ps_mesh.add_color_quantity(f"{name}_colors", np.tile(
+        color, (len(vertices), 1)), defined_on='vertices', enabled=True)
+
+    arrow_mesh = []
+    for i in range(len(points)):
+        arrow_mesh += [GeometryPrimitives.CreateArrow(endpoints=np.array(
+            [[0, 0, 0], points[i]]), color=color)]
+    arrow_mesh = GeometryPrimitives.CollapseMeshObjects(arrow_mesh)
+    ps_arrows = ps.register_surface_mesh("cone_arrows", np.asarray(
+        arrow_mesh.vertices), np.asarray(arrow_mesh.triangles), transparency=arrow_alpha, smooth_shade=True)
+    ps_arrows.add_color_quantity("cone_arrows_colors", np.asarray(
+        arrow_mesh.vertex_colors), defined_on='vertices', enabled=True)
+
+    edges = np.array([[i, (i + 1) % len(points)] for i in range(len(points))])
+    ps_net = ps.register_curve_network(f"{name}_curve", points, edges)
+    ps_net.add_color_quantity(f"{name}_curve_colors", np.tile(
+        color, (len(points), 1)), defined_on='nodes', enabled=True)
+
+
+def Render3DLine(name: str, points: npt.NDArray, color: npt.ArrayLike, line_alpha: float = 1) -> None:
+    """Create a 3D line from a list of vertices (N x 3) and a color (3)
+
+    Args:
+        name (str): basename for the line asset
+        points (npt.NDArray): N x 3 array of vertices
+        color (npt.ArrayLike): 1 x 3 Array of RGB color
+        line_alpha (float, optional): Transparency of the Line. Defaults to 1.
+    """
+    edges = np.array([[i, (i + 1) % len(points)] for i in range(len(points))])
+    ps_net = ps.register_curve_network(f"{name}_curve", points, edges)
+    ps_net.add_color_quantity(f"{name}_curve_colors", np.tile(
+        color, (len(points), 1)), defined_on='nodes', enabled=True)
+
+
+def RenderConeOBS(name: str, observer: Observer) -> None:
+    chrom_points, rgbs = observer.get_optimal_colors()
+    if observer.dimension > 3:
+        chrom_points = (GetHeringMatrix(observer.dimension)@chrom_points.T).T[:, 1:]
+
+    Render3DMesh(f"{name}_mesh", chrom_points, rgbs)
+
+
+def RenderMaxBasisOBS(name: str, observer: Observer) -> None:
+    chrom_points, rgbs = observer.get_optimal_colors()
+    maxbasis = MaxBasisFactory.get_object(observer)
+    T = maxbasis.get_transformation_matrix()
+    chrom_points = chrom_points@T.T
+
+    if observer.dimension > 3:
+        chrom_points = (GetHeringMatrix(observer.dimension)@chrom_points.T).T[:, 1:]
+
+    Render3DMesh(f"{name}_mesh", chrom_points, rgbs)
+
+
+def RenderDisplayGamut(name: str, basis_vectors: npt.NDArray):
+    gamut_edges = GeometryPrimitives.CreateParallelotopeEdges(basis_vectors, color=[1, 1, 1])
+    GeometryPrimitives.ConvertTriangleMeshToPolyscope(name + "_edges", gamut_edges)
+
+    gamut = GeometryPrimitives.CreateParallelotopeMesh(basis_vectors, color=[1, 1, 1])
+    GeometryPrimitives.ConvertTriangleMeshToPolyscope(name + "_mesh", gamut)
+
+
+def RenderPointCloud(name: str, points: npt.NDArray, rgb: npt.NDArray | None = None) -> None:
+    """Render a point cloud in Polyscope
+
+    Args:
+        name (str): Name of the point cloud
+        points (npt.Array): N x 3 array of vertices
+        rgb (npt.NDArray | None, optional): N x 3 array of RGB colors. Defaults to None.
+    """
+    pcl = ps.register_point_cloud(name, points)
+    if rgb is not None:
+        pcl.add_color_quantity(f"{name}_colors", rgb, enabled=True)
+
+
+def RenderGridOfArrows(name: str):
+    grid_size = 10
+    arrow_length = 1.0
+    grid_range = np.linspace(-arrow_length/2, arrow_length/2, grid_size)
+    arrow_mesh = []
+    for x in grid_range:
+        for y in grid_range:
+            arrow = GeometryPrimitives.CreateArrow(np.array([[x, y, -arrow_length/2], [x, y, arrow_length/2]]))
+            GeometryPrimitives.ConvertTriangleMeshToPolyscope(name, arrow)
+    arrow_mesh = GeometryPrimitives.CollapseMeshObjects(arrow_mesh)
+    GeometryPrimitives.ConvertTriangleMeshToPolyscope(name, arrow_mesh)

--- a/TetriumColor/Visualization/PolyscopeUtils.py
+++ b/TetriumColor/Visualization/PolyscopeUtils.py
@@ -12,11 +12,24 @@ from ..Observer import Observer, MaxBasisFactory, GetHeringMatrix
 from .Animation import AnimationUtils
 
 
-def OpenVideo(filename):
+def OpenVideo(filename: str):  # dunno how to type a fd
+    """Open a video file for writing.
+
+    Args:
+        filename (str): filename
+
+    Returns:
+        file descriptor: file descriptor for the video file
+    """
     return ps.open_video_file(filename, fps=30)
 
 
-def CloseVideo(fd):
+def CloseVideo(fd) -> None:
+    """Close the video file descriptor
+
+    Args:
+        fd (dunno): file descriptor
+    """
     ps.close_video_file(fd)
     return
 
@@ -39,16 +52,13 @@ def RenderVideo(fd, total_frames: int, target_fps: int = 30):
         ps.write_video_frame(fd, transparent_bg=False)
 
 
-def Render3DMesh(name: str, points: npt.ArrayLike, rgbs: npt.ArrayLike, mesh_alpha: float = 1) -> None:
+def Render3DMesh(name: str, points: npt.ArrayLike, rgbs: npt.ArrayLike) -> None:
     """Create a 3D mesh from a list of vertices (N x 3) and RGB colors (N x 3)
 
     Args:
         name (str): Name of the mesh
         points (npt.ArrayLike): N x 3 array of vertices
         rgbs (npt.ArrayLike): N x 3 array of RGB colors
-
-    Returns:
-        _type_: _description_
     """
     mesh = GeometryPrimitives.Create3DMesh(points, rgbs)
     GeometryPrimitives.ConvertTriangleMeshToPolyscope(name, mesh)
@@ -104,6 +114,12 @@ def Render3DLine(name: str, points: npt.NDArray, color: npt.ArrayLike, line_alph
 
 
 def RenderConeOBS(name: str, observer: Observer) -> None:
+    """Create an Object Color Solid in the Cone Basis in Polyscope
+
+    Args:
+        name (str): name of object to register with polyscope
+        observer (Observer): Observer object to render
+    """
     chrom_points, rgbs = observer.get_optimal_colors()
     if observer.dimension > 3:
         chrom_points = (GetHeringMatrix(observer.dimension)@chrom_points.T).T[:, 1:]
@@ -112,6 +128,13 @@ def RenderConeOBS(name: str, observer: Observer) -> None:
 
 
 def RenderOBSTransform(name: str, observer: Observer, T: npt.NDArray) -> None:
+    """Render an Object Color Solid by transforming points before. 
+
+    Args:
+        name (str): name of object to register with polyscope 
+        observer (Observer): Observer object to render
+        T (npt.NDArray): Transformation matrix to apply to the points
+    """
     chrom_points, rgbs = observer.get_optimal_colors()
     chrom_points = chrom_points@T.T
 
@@ -122,12 +145,24 @@ def RenderOBSTransform(name: str, observer: Observer, T: npt.NDArray) -> None:
 
 
 def RenderMaxBasisOBS(name: str, observer: Observer) -> None:
+    """Render Object Color Solid in Max Basis
+
+    Args:
+        name (str): name of object to register with polyscope
+        observer (Observer): Observer object to render
+    """
     maxbasis = MaxBasisFactory.get_object(observer)
     T = maxbasis.GetConeToMaxBasisTransform()
     RenderOBSTransform(name, observer, T)
 
 
 def RenderHeringBasisOBS(name: str, observer: Observer) -> None:
+    """Render Object Color Solid in Hering Basis
+
+    Args:
+        name (str): name of object to register with polyscope
+        observer (Observer): Observer object to render
+    """
     maxbasis = MaxBasisFactory.get_object(observer)
     T = maxbasis.GetConeToMaxBasisTransform()
     if observer.dimension > 3:  # will be transformed either way in next function call
@@ -138,6 +173,13 @@ def RenderHeringBasisOBS(name: str, observer: Observer) -> None:
 
 
 def RenderOBS(name: str, observer: Observer, display_basis: DisplayBasisType) -> None:
+    """Render Object Color Solid in Specified Basis
+
+    Args:
+        name (str): name of object to register with polyscope
+        observer (Observer): Observer object to render
+        display_basis (DisplayBasisType): Basis to render the object in
+    """
     if display_basis == DisplayBasisType.Cone:
         RenderConeOBS(name, observer)
     elif display_basis == DisplayBasisType.MaxBasis:
@@ -147,6 +189,13 @@ def RenderOBS(name: str, observer: Observer, display_basis: DisplayBasisType) ->
 
 
 def RenderMaxBasis(name: str, observer: Observer, display_basis: DisplayBasisType = DisplayBasisType.MaxBasis) -> None:
+    """Render Max Basis Objects of Points and Lines - A Luminance Projected Parallelotope. 
+
+    Args:
+        name (str): name of object to register with polyscope
+        observer (Observer): Observer object to render
+        display_basis (DisplayBasisType, optional): Display Basis to Render in. Defaults to DisplayBasisType.MaxBasis.
+    """
     maxbasis = MaxBasisFactory.get_object(observer)
     _, points, rgbs, lines = maxbasis.GetDiscreteRepresentation()
     # go into hering if dim is > 3
@@ -168,6 +217,12 @@ def RenderMaxBasis(name: str, observer: Observer, display_basis: DisplayBasisTyp
 
 
 def RenderDisplayGamut(name: str, basis_vectors: npt.NDArray):
+    """Render Display Gamut in Polyscope
+
+    Args:
+        name (str): Name of the gamut to be registered with polyscope
+        basis_vectors (npt.NDArray): basis vectors of the paralleletope gamut
+    """
     gamut_edges = GeometryPrimitives.CreateParallelotopeEdges(basis_vectors, color=[1, 1, 1])
     gamut = GeometryPrimitives.CreateParallelotopeMesh(basis_vectors, color=[1, 1, 1])
 
@@ -189,6 +244,11 @@ def RenderPointCloud(name: str, points: npt.NDArray, rgb: npt.NDArray | None = N
 
 
 def RenderGridOfArrows(name: str):
+    """Render a grid of arrows in Polyscope
+
+    Args:
+        name (str): Name to be registered with polyscope
+    """
     grid_size = 10
     arrow_length = 1.0
     grid_range = np.linspace(-arrow_length/2, arrow_length/2, grid_size)

--- a/TetriumColor/Visualization/__init__.py
+++ b/TetriumColor/Visualization/__init__.py
@@ -1,0 +1,3 @@
+from .PolyscopeUtils import *
+from .Animation import *
+from .Geometry import *

--- a/TetriumColor/__init__.py
+++ b/TetriumColor/__init__.py
@@ -1,1 +1,2 @@
 # Tetrium Color - A color library for Python
+from .Utils.CustomTypes import *

--- a/scripts/visualization/observer-viz.py
+++ b/scripts/visualization/observer-viz.py
@@ -53,8 +53,8 @@ def main():
     viz.AnimationUtils.AddObject("tetra-max-basis", "surface_mesh", position, velocity, rotation_axis, rotation_speed)
 
     # Output Video to Screen or Save to File (based on options)
-    if args.output:
-        fd = viz.OpenVideo(args.output)
+    if args.output_filename:
+        fd = viz.OpenVideo(args.output_filename)
         viz.RenderVideo(fd, args.total_frames, args.fps)
         viz.CloseVideo(fd)
     else:

--- a/scripts/visualization/observer-viz.py
+++ b/scripts/visualization/observer-viz.py
@@ -1,0 +1,36 @@
+import argparse
+import numpy as np
+import tetrapolyscope as ps
+
+from TetriumColor.Observer import GetCustomTetraObserver
+from TetriumColor import DisplayBasisType
+import TetriumColor.Visualization as viz
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Visualize Custom Tetra Observer.')
+    parser.add_argument('--display_basis', type=lambda choice: DisplayBasisType[choice], choices=list(DisplayBasisType))
+    parser.add_argument('--od', type=float, required=False, default=0.5, help='Optical Density')
+    parser.add_argument('--s_cone_peak', type=int, required=False, default=419, help='S cone peak')
+    parser.add_argument('--m_cone_peak', type=int, required=False, default=530, help='M cone peak')
+    parser.add_argument('--l_cone_peak', type=int, required=False, default=559, help='L cone peak')
+    parser.add_argument('--q_cone_peak', type=int, required=False, default=547, help='Q cone peak')
+    parser.add_argument('--macula', type=float, required=False, default=1.0, help='Macula Pigment Density')
+    parser.add_argument('--lens', type=float, required=False, default=1.0, help='Lens Density')
+    parser.add_argument('--template', type=str, required=False, default='neitz',
+                        help='Template for the cone fundamentals used')
+    parser.add_argument("--verbose", type=bool, default=True, help="Verbose output")
+    args = parser.parse_args()
+
+    wavelengths = np.arange(380, 781, 10)
+    observer = GetCustomTetraObserver(wavelengths, args.od, args.s_cone_peak, args.m_cone_peak, args.q_cone_peak,
+                                      args.l_cone_peak, args.macula, args.lens, args.template)
+
+    ps.init()
+    viz.RenderOBS("tetra-custom-observer", observer, args.display_basis)
+    viz.RenderMaxBasis("tetra-max-basis", observer, display_basis=args.display_basis)
+    ps.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/visualization/observer-viz.py
+++ b/scripts/visualization/observer-viz.py
@@ -1,6 +1,7 @@
 import argparse
 import numpy as np
 import tetrapolyscope as ps
+import time
 
 from TetriumColor.Observer import GetCustomTetraObserver
 from TetriumColor import DisplayBasisType
@@ -20,16 +21,47 @@ def main():
     parser.add_argument('--template', type=str, required=False, default='neitz',
                         help='Template for the cone fundamentals used')
     parser.add_argument("--verbose", type=bool, default=True, help="Verbose output")
+
+    # Parser Args for Animation / Video Saving
+    parser.add_argument("--output_filename", type=str, required=False,
+                        help="Output file name. If none is specified, the video will not be saved.")
+    parser.add_argument("--fps", type=int, default=30, help="Frames per second for the video")
+    parser.add_argument("--total_frames", type=int, default=200, help="Total number of frames to render")
+
     args = parser.parse_args()
 
+    # Observer attributes
     wavelengths = np.arange(380, 781, 10)
     observer = GetCustomTetraObserver(wavelengths, args.od, args.s_cone_peak, args.m_cone_peak, args.q_cone_peak,
                                       args.l_cone_peak, args.macula, args.lens, args.template)
 
+    # Polyscope Animation Inits
     ps.init()
+    position = [0, 0, 0]
+    velocity = [0, 0, 0]  # [-0.02, 0, 0]
+    rotation_speed = 3
+    rotation_axis = [0, 1, 0]
+
+    # Create Geometry & Register with Polyscope, and define the animation
     viz.RenderOBS("tetra-custom-observer", observer, args.display_basis)
+    ps.get_surface_mesh("tetra-custom-observer").set_transparency(0.5)
+
+    viz.AnimationUtils.AddObject("tetra-custom-observer", "surface_mesh",
+                                 position, velocity, rotation_axis, rotation_speed)
+
     viz.RenderMaxBasis("tetra-max-basis", observer, display_basis=args.display_basis)
-    ps.show()
+    viz.AnimationUtils.AddObject("tetra-max-basis", "surface_mesh", position, velocity, rotation_axis, rotation_speed)
+
+    # Output Video to Screen or Save to File (based on options)
+    if args.output:
+        fd = viz.OpenVideo(args.output)
+        viz.RenderVideo(fd, args.total_frames, args.fps)
+        viz.CloseVideo(fd)
+    else:
+        delta_time: float = 1 / args.fps
+        while True:
+            viz.AnimationUtils.UpdateObjects(delta_time)
+            ps.frame_tick()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- We have a library for defining geometry using open3d. Open3D makes defining geometry really simple, and less work on our end.
- We then have an interface for connecting creation of geometry with the Observer sub-library of TetriumColor. This will allow us to define any observer, and then render. The main difference with chromalab is that now the polyscope instance is decoupled with the observer. Before we had a class that you had to call in order to render a bunch of stuff. Now, we have just made them all methods that take an observer in. Therefore, you can have multiple observers. Probably not that much functionally different but it makes the code much more simple, and easy to read. It's all commented as well, so it should be easy to use when we want to analyze stuff.
- Animation is now defined in a canonical way. When you register a polyscope object, you can also choose to add it to the Animations dictionary, which has the position, velocity, rotation axis, and rotation speed defined. The script can then either save it to a video and run it at a certain fps, or you can run the animation in the polyscope interface. This will make it really easy to generate assets come submission time!
- Yay! Finally done with this